### PR TITLE
fix: styling for light mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -22,7 +22,7 @@
   --success-text-colour: #6DD58C;
 }
 
-.light :root {
+.light {
   --background-color: #FFF;
   --text-color: #1f1f1f;
   --active-text-color: #a8c7fa;

--- a/src/panels/menu.css
+++ b/src/panels/menu.css
@@ -16,7 +16,7 @@
 }
 
 .Menu button:hover {
-  color: #FFF;
+  color: var(--primary-action-color-hover);
 }
 
 .Menu button.selected {


### PR DESCRIPTION
This PR fixes the styling:
-  when dev tools is configured to light mode. Because the `light` css theme class is added to the `body` element rather than the `html` element. So none of the light theme variable overrides work.
- Additionally make sure that links don't become invisible when hovered (by using `--primary-action-color-hover`)

### Before

<img width="1169" alt="Screenshot 2024-07-12 at 2 49 55 pm" src="https://github.com/user-attachments/assets/406b55f4-28f8-4808-8f15-2ac09752c78c">

### After
<img width="1166" alt="Screenshot 2024-07-12 at 2 52 29 pm" src="https://github.com/user-attachments/assets/47b4af79-9cba-48a3-9f3b-964cdcf2fa24">
